### PR TITLE
feat: add icons to buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-icons": "^4.11.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/src/components/add-text/index.tsx
+++ b/src/components/add-text/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { FaPlus } from 'react-icons/fa';
 
 interface AddTextProps {
     onSubmit: (text: string, position: 'top' | 'bottom') => void;
@@ -24,7 +25,9 @@ function AddText({ onSubmit, position }: AddTextProps) {
                 type="text"
                 placeholder={position[0].toUpperCase() + position.slice(1)}
             />
-            <button onClick={handleSubmit}>Add text</button>
+            <button onClick={handleSubmit}>
+                <FaPlus /> Add text
+            </button>
         </div>
     );
 }

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -3,6 +3,7 @@ import AddText from '@components/add-text';
 import Upload from '@components/upload';
 import { getRandomColor } from '@shared/lib/color';
 import { MAX_CANVAS_HEIGHT, MAX_CANVAS_WIDTH } from '@shared/constants/canvas-constants';
+import { FaPalette, FaTrash, FaDownload } from 'react-icons/fa';
 
 function Main() {
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -142,7 +143,9 @@ function Main() {
                     gap: 16,
                 }}
             >
-                <button onClick={handleFill}>Random Color</button>
+                <button onClick={handleFill}>
+                    <FaPalette /> Random Color
+                </button>
 
                 <Upload onChange={handleChangePicture} />
 
@@ -150,9 +153,13 @@ function Main() {
 
                 <AddText onSubmit={handleAddText} position="bottom" />
 
-                <button onClick={handleClear}>Clear</button>
+                <button onClick={handleClear}>
+                    <FaTrash /> Clear
+                </button>
 
-                <button onClick={handleDownloadImage}>Download</button>
+                <button onClick={handleDownloadImage}>
+                    <FaDownload /> Download
+                </button>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- add react-icons dependency
- show icons on text, color, clear and download buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c83212b488321860c31aa736ecd1d