### PR TITLE
feat: enable text dragging

### DIFF
--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -7,9 +7,16 @@ import { FaPalette, FaTrash, FaDownload } from 'react-icons/fa';
 
 function Main() {
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const containerRef = useRef<HTMLDivElement | null>(null);
 
     const [context, setContext] = useState<CanvasRenderingContext2D | null | undefined>(null);
     const [image, setImage] = useState<string | ArrayBuffer | null>();
+    const [texts, setTexts] = useState<
+        { id: number; text: string; x: number; y: number }[]
+    >([]);
+    const [dragging, setDragging] = useState<
+        { index: number; offsetX: number; offsetY: number } | null
+    >(null);
 
     const handleChangePicture = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
@@ -29,57 +36,51 @@ function Main() {
             bottom: { x: 40, y: MAX_CANVAS_HEIGHT - 40 - 30 },
         };
 
-        if (context) {
-            context.font = 'bold 30px Arial';
-            context.fillStyle = 'white';
-            context.textBaseline = 'top'; // Установка базовой линии текста
-            context.fillText(text, textCoords[position].x, textCoords[position].y, MAX_CANVAS_WIDTH - 16);
-            context.strokeStyle = 'black';
-            context.lineWidth = 1;
-            context.strokeText(text, textCoords[position].x, textCoords[position].y);
-        }
+        setTexts((prev) => [
+            ...prev,
+            {
+                id: Date.now(),
+                text,
+                x: textCoords[position].x,
+                y: textCoords[position].y,
+            },
+        ]);
     };
 
-    const drawImageOnCanvas = () => {
-        if (image) {
-            const canvas = canvasRef.current;
-            const img = new Image();
+    const handleMouseDown = (index: number, e: React.MouseEvent<HTMLDivElement>) => {
+        const rect = containerRef.current?.getBoundingClientRect();
+        if (!rect) return;
+        setDragging({
+            index,
+            offsetX: e.clientX - rect.left - texts[index].x,
+            offsetY: e.clientY - rect.top - texts[index].y,
+        });
+    };
 
-            if (typeof image === 'string') {
-                img.src = image;
+    useEffect(() => {
+        const handleMouseMove = (e: MouseEvent) => {
+            if (dragging) {
+                const rect = containerRef.current?.getBoundingClientRect();
+                if (!rect) return;
+                const x = e.clientX - rect.left - dragging.offsetX;
+                const y = e.clientY - rect.top - dragging.offsetY;
+                setTexts((prev) =>
+                    prev.map((t, i) => (i === dragging.index ? { ...t, x, y } : t)),
+                );
             }
+        };
 
-            img.onload = () => {
-                let width = img.width;
-                let height = img.height;
+        const handleMouseUp = () => setDragging(null);
 
-                if (img.width > MAX_CANVAS_WIDTH) {
-                    img.width = MAX_CANVAS_WIDTH;
-                }
+        document.addEventListener('mousemove', handleMouseMove);
+        document.addEventListener('mouseup', handleMouseUp);
 
-                if (img.height > MAX_CANVAS_HEIGHT) {
-                    img.height = MAX_CANVAS_HEIGHT;
-                }
+        return () => {
+            document.removeEventListener('mousemove', handleMouseMove);
+            document.removeEventListener('mouseup', handleMouseUp);
+        };
+    }, [dragging]);
 
-                // Сохраняем пропорции изображения
-                if (width > height) {
-                    if (width > MAX_CANVAS_WIDTH) {
-                        height *= MAX_CANVAS_WIDTH / width;
-                        width = MAX_CANVAS_WIDTH;
-                    }
-                } else {
-                    if (height > MAX_CANVAS_HEIGHT) {
-                        width *= MAX_CANVAS_HEIGHT / height;
-                        height = MAX_CANVAS_HEIGHT;
-                    }
-                }
-
-                if (canvas) {
-                    context?.drawImage(img, 0, 0, width, height);
-                }
-            };
-        }
-    };
 
     const handleFill = () => {
         if (context) {
@@ -92,13 +93,34 @@ function Main() {
         if (context) {
             context.clearRect(0, 0, MAX_CANVAS_WIDTH, MAX_CANVAS_WIDTH);
         }
+        setTexts([]);
     };
 
     const handleDownloadImage = () => {
         const canvas = canvasRef.current;
 
-        if (canvas) {
+        if (canvas && context) {
+            const baseImage = context.getImageData(
+                0,
+                0,
+                MAX_CANVAS_WIDTH,
+                MAX_CANVAS_HEIGHT,
+            );
+
+            texts.forEach((t) => {
+                context.font = 'bold 30px Arial';
+                context.fillStyle = 'white';
+                context.textBaseline = 'top';
+                context.fillText(t.text, t.x, t.y, MAX_CANVAS_WIDTH - 16);
+                context.strokeStyle = 'black';
+                context.lineWidth = 1;
+                context.strokeText(t.text, t.x, t.y);
+            });
+
             const imageURI = canvas.toDataURL('image/jpeg');
+
+            context.putImageData(baseImage, 0, 0);
+
             const link = document.createElement('a');
             link.href = imageURI;
             link.download = 'image.jpg';
@@ -112,9 +134,42 @@ function Main() {
         setContext(canvasRef.current?.getContext('2d'));
     }, []);
 
-    if (image) {
-        drawImageOnCanvas();
-    }
+    useEffect(() => {
+        if (typeof image === 'string' && context) {
+            const canvas = canvasRef.current;
+            const img = new Image();
+            img.src = image;
+
+            img.onload = () => {
+                let width = img.width;
+                let height = img.height;
+
+                if (img.width > MAX_CANVAS_WIDTH) {
+                    img.width = MAX_CANVAS_WIDTH;
+                }
+
+                if (img.height > MAX_CANVAS_HEIGHT) {
+                    img.height = MAX_CANVAS_HEIGHT;
+                }
+
+                if (width > height) {
+                    if (width > MAX_CANVAS_WIDTH) {
+                        height *= MAX_CANVAS_WIDTH / width;
+                        width = MAX_CANVAS_WIDTH;
+                    }
+                } else {
+                    if (height > MAX_CANVAS_HEIGHT) {
+                        width *= MAX_CANVAS_HEIGHT / height;
+                        height = MAX_CANVAS_HEIGHT;
+                    }
+                }
+
+                if (canvas) {
+                    context.drawImage(img, 0, 0, width, height);
+                }
+            };
+        }
+    }, [image, context]);
 
     return (
         <div
@@ -126,13 +181,40 @@ function Main() {
                 gap: 16,
             }}
         >
-            <canvas
-                ref={canvasRef}
-                style={{ background: '#fff' }}
-                id="myCanvas"
-                width="500"
-                height="500"
-            />
+            <div
+                ref={containerRef}
+                style={{ position: 'relative', width: 500, height: 500 }}
+            >
+                <canvas
+                    ref={canvasRef}
+                    style={{ background: '#fff' }}
+                    id="myCanvas"
+                    width="500"
+                    height="500"
+                />
+
+                {texts.map((t, index) => (
+                    <div
+                        key={t.id}
+                        onMouseDown={(e) => handleMouseDown(index, e)}
+                        style={{
+                            position: 'absolute',
+                            left: t.x,
+                            top: t.y,
+                            color: '#fff',
+                            fontWeight: 'bold',
+                            fontSize: 30,
+                            fontFamily: 'Arial',
+                            cursor: 'move',
+                            userSelect: 'none',
+                            textShadow:
+                                '-1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000',
+                        }}
+                    >
+                        {t.text}
+                    </div>
+                ))}
+            </div>
 
             <div
                 style={{


### PR DESCRIPTION
## Summary
- add stateful text overlays and drag logic to reposition text
- include text overlays when generating downloadable image

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c854883648321b888bb2900bda752