### PR TITLE
refactor: move inline styles to css modules

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,16 +1,10 @@
 import Main from '../pages/main';
 import Header from '../widgets/header';
+import styles from './styles.module.css';
 
 function App() {
     return (
-        <main
-            style={{
-                width: '100%',
-                display: 'grid',
-                gridTemplateColumns: '1fr',
-                gridTemplateRows: 'min-content 1fr',
-            }}
-        >
+        <main className={styles.main}>
             <Header />
 
             <Main />

--- a/src/app/styles.module.css
+++ b/src/app/styles.module.css
@@ -1,0 +1,6 @@
+.main {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: min-content 1fr;
+}

--- a/src/components/add-text/index.tsx
+++ b/src/components/add-text/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { FaPlus } from 'react-icons/fa';
+import styles from './styles.module.css';
 
 interface AddTextProps {
     onSubmit: (text: string, position: 'top' | 'bottom') => void;
@@ -17,11 +18,9 @@ function AddText({ onSubmit, position }: AddTextProps) {
     };
 
     return (
-        <div
-            style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}
-        >
+        <div className={styles.container}>
             <input
-                style={{ width: '60%' }}
+                className={styles.input}
                 value={inputValue}
                 onChange={(e) => setInputValue(e.target.value)}
                 type="text"

--- a/src/components/add-text/styles.module.css
+++ b/src/components/add-text/styles.module.css
@@ -1,0 +1,9 @@
+.container {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.input {
+    width: 60%;
+}

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -3,6 +3,7 @@ import AddText from '@components/add-text';
 import Upload from '@components/upload';
 import { FaPalette, FaTrash, FaDownload, FaUndo, FaRedo } from 'react-icons/fa';
 import useCanvas from '@shared/hooks/use-canvas';
+import styles from './styles.module.css';
 
 function Main() {
     const containerRef = useRef<HTMLDivElement | null>(null);
@@ -188,28 +189,17 @@ function Main() {
     }, [image, texts]);
 
     return (
-        <div
-            style={{
-                width: '100%',
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                gap: 16,
-            }}
-        >
+        <div className={styles.container}>
             <div
                 ref={containerRef}
-                style={{
-                    position: 'relative',
-                    width: canvasWidth,
-                    height: canvasHeight,
-                }}
+                className={styles.canvasContainer}
+                style={{ width: canvasWidth, height: canvasHeight }}
                 onDrop={handleDropPicture}
                 onDragOver={handleDragOver}
             >
                 <canvas
                     ref={canvasRef}
-                    style={{ background: '#fff' }}
+                    className={styles.canvas}
                     id="myCanvas"
                     width={canvasWidth}
                     height={canvasHeight}
@@ -219,34 +209,15 @@ function Main() {
                     <div
                         key={t.id}
                         onMouseDown={(e) => handleMouseDown(index, e)}
-                        style={{
-                            position: 'absolute',
-                            left: t.x,
-                            top: t.y,
-                            color: '#fff',
-                            fontWeight: 'bold',
-                            fontSize: 30,
-                            fontFamily: 'Arial',
-                            cursor: 'move',
-                            userSelect: 'none',
-                            textShadow:
-                                '-1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000',
-                        }}
+                        className={styles.text}
+                        style={{ left: t.x, top: t.y }}
                     >
                         {t.text}
                     </div>
                 ))}
             </div>
 
-            <div
-                style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    height: 500,
-                    width: 360,
-                    gap: 16,
-                }}
-            >
+            <div className={styles.sidebar}>
                 <button onClick={handleFill}>
                     <FaPalette /> Random Color
                 </button>

--- a/src/pages/main/styles.module.css
+++ b/src/pages/main/styles.module.css
@@ -1,0 +1,38 @@
+.container {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 16px;
+}
+
+.canvasContainer {
+    position: relative;
+}
+
+.canvas {
+    background: #fff;
+}
+
+.text {
+    position: absolute;
+    color: #fff;
+    font-weight: bold;
+    font-size: 30px;
+    font-family: Arial;
+    cursor: move;
+    user-select: none;
+    text-shadow:
+        -1px -1px 0 #000,
+        1px -1px 0 #000,
+        -1px 1px 0 #000,
+        1px 1px 0 #000;
+}
+
+.sidebar {
+    display: flex;
+    flex-direction: column;
+    height: 500px;
+    width: 360px;
+    gap: 16px;
+}

--- a/src/widgets/header/index.tsx
+++ b/src/widgets/header/index.tsx
@@ -1,6 +1,8 @@
+import styles from './styles.module.css';
+
 function Header() {
     return (
-        <header style={{ paddingLeft: 16 }}>
+        <header className={styles.header}>
             <h1>Memash</h1>
         </header>
     );

--- a/src/widgets/header/styles.module.css
+++ b/src/widgets/header/styles.module.css
@@ -1,0 +1,3 @@
+.header {
+    padding-left: 16px;
+}


### PR DESCRIPTION
## Summary
- refactor components to use CSS modules instead of inline styles

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_689c933423108321a6e42e70d8745998